### PR TITLE
Added arm64 rpm builds in rpm build extras script.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ workflows:
              branches:
                only:
                  - master
-     jobs:
+    jobs:
       - pkgbuilds
       - deploypkg:
           requires: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,14 +124,14 @@ workflows:
       - installtests
       - linktests
   build:
-   jobs:
-      - triggers:
-       - schedule:
+    triggers:
+      - schedule:
            cron: "0 0 * * *"
            filters:
              branches:
                only:
                  - master
+     jobs:
       - pkgbuilds
       - deploypkg:
           requires: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,6 @@ jobs:
       - store_artifacts:
             path: /tmp/pkgs
   deploypkg:
-    branches:
-      only:
-        - master
     docker:
       - image: circleci/ruby:2.3-jessie
     steps:
@@ -128,6 +125,13 @@ workflows:
       - linktests
   build:
    jobs:
+      - triggers:
+       - schedule:
+           cron: "0 0 * * *"
+           filters:
+             branches:
+               only:
+                 - master
       - pkgbuilds
       - deploypkg:
           requires: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,9 @@ jobs:
       - store_artifacts:
             path: /tmp/pkgs
   deploypkg:
+    branches:
+      only:
+        - master
     docker:
       - image: circleci/ruby:2.3-jessie
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,22 +101,22 @@ jobs:
           command: package_cloud push whitewaterfoundry/wslu/fedora/29 /tmp/pkgs/*.x86_64.rpm --skip-errors
       - run:
           name: Push rpm package for enterprise linux 7
-          command: package_cloud push whitewaterfoundry/wslu/el/7 /tmp/pkgs/*.x86_64.rpm --skip-errors
+          command: package_cloud push whitewaterfoundry/wslu/el/7 /tmp/pkgs/*.rpm --skip-errors
       - run:
           name: Push rpm package for scientific linux 7
-          command: package_cloud push whitewaterfoundry/wslu/scientific/7 /tmp/pkgs/*.x86_64.rpm --skip-errors
+          command: package_cloud push whitewaterfoundry/wslu/scientific/7 /tmp/pkgs/*.rpm --skip-errors
       - run:
           name: Push rpm package for sles 12
-          command: package_cloud push whitewaterfoundry/wslu/sles/12.0 /tmp/pkgs/*.x86_64.rpm --skip-errors
+          command: package_cloud push whitewaterfoundry/wslu/sles/12.0 /tmp/pkgs/*.rpm --skip-errors
       - run:
           name: Push rpm package for sles 15
-          command: package_cloud push whitewaterfoundry/wslu/sles/15.0 /tmp/pkgs/*.x86_64.rpm --skip-errors
+          command: package_cloud push whitewaterfoundry/wslu/sles/15.0 /tmp/pkgs/*.rpm --skip-errors
       - run:
           name: Push rpm package for opensuse 42.3
-          command: package_cloud push whitewaterfoundry/wslu/opensuse/42.3 /tmp/pkgs/*.x86_64.rpm --skip-errors
+          command: package_cloud push whitewaterfoundry/wslu/opensuse/42.3 /tmp/pkgs/*.rpm --skip-errors
       - run:
           name: Push rpm package for opensuse 15
-          command: package_cloud push whitewaterfoundry/wslu/opensuse/15.0 /tmp/pkgs/*.x86_64.rpm --skip-errors
+          command: package_cloud push whitewaterfoundry/wslu/opensuse/15.0 /tmp/pkgs/*.rpm --skip-errors
 workflows:
   version: 2
   tests:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 target
+.vscode

--- a/extras/scripts/builder-rpm.sh
+++ b/extras/scripts/builder-rpm.sh
@@ -47,8 +47,8 @@ rm -rf wslu-$BUILD_VER
 
 # Build
 cd ~/rpm_wslu/SPECS
-sudo rpmbuild -ba --buildarch x86_64 wslu-$BUILD_VER.spec
-sudo rpmbuild -ba --buildarch arm64 wslu-$BUILD_VER.spec
+sudo rpmbuild -ba --target x86_64 wslu-$BUILD_VER.spec
+sudo rpmbuild -ba --target arm64 wslu-$BUILD_VER.spec
 
 # Copy packages
 [ -d $CURRENT_DIR/../../target ] || mkdir $CURRENT_DIR/../../target

--- a/extras/scripts/builder-rpm.sh
+++ b/extras/scripts/builder-rpm.sh
@@ -47,11 +47,13 @@ rm -rf wslu-$BUILD_VER
 
 # Build
 cd ~/rpm_wslu/SPECS
-sudo rpmbuild -ba wslu-$BUILD_VER.spec
+sudo rpmbuild -ba --buildarch x86_64 wslu-$BUILD_VER.spec
+sudo rpmbuild -ba --buildarch arm64 wslu-$BUILD_VER.spec
 
 # Copy packages
 [ -d $CURRENT_DIR/../../target ] || mkdir $CURRENT_DIR/../../target
 cp ~/rpm_wslu/RPMS/x86_64/*.rpm $CURRENT_DIR/../../target/
+cp ~/rpm_wslu/RPMS/arm64/*.rpm $CURRENT_DIR/../../target/
 cp ~/rpm_wslu/SRPMS/*.rpm $CURRENT_DIR/../../target/
 
 # Cleanup everything


### PR DESCRIPTION
## Description
Added arm64 rpm builds in rpm build extras script by adding target settings for both x86_64 and arm64.

Wildcards handle the rest and push x86_64, arm64, and source to packageloud.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read Code of Conduct and Contributing documentations.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.