### PR TITLE
Fixed issue with leading spaces in root folder path in wsl.conf

### DIFF
--- a/src/wslu-header
+++ b/src/wslu-header
@@ -75,7 +75,7 @@ function double_dash_p {
 
 function interop_prefix {
 	if [ -f /etc/wsl.conf ]; then
-		tmp=$(awk -F '=' '/root/ {print $2}' /etc/wsl.conf)
+		tmp=$(awk -F '=' '/root/ {print $2}' /etc/wsl.conf | awk '{$1=$1;print}')
 		if [ "$tmp" == "" ]; then
 			echo "/mnt/"
 		else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When in wsl.conf file mount points root path is preceded by spaces, executing some of utilities ends with error:

`/usr/bin/wslview: line 90:  /c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe: No such file or directory`

This problem is caused by leading spaces ending up in result of `interop_prefix` function.
I used command from [https://unix.stackexchange.com/a/205854](https://unix.stackexchange.com/a/205854) to get rid of leading and trailing spaces before returning from that function.

Example `wsl.conf` file that caused problem
```
[automount]
enabled = true
root = /
mountFsTab = true
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read Code of Conduct and Contributing documentations.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.