### PR TITLE
svg icon conversion remove white border

### DIFF
--- a/src/wslusc.sh
+++ b/src/wslusc.sh
@@ -69,7 +69,11 @@ if [[ "$cname" != "" ]]; then
 			cp "$iconpath" "$script_location"
 		
 			if [[ "$ext" != "ico" ]]; then
-				if [[ "$ext" == "svg" ]] || [[ "$ext" == "png" ]] || [[ "$ext" == "xpm" ]]; then
+				if [[ "$ext" == "svg" ]]; then
+					echo "${info} Converting $ext icon to ico..."
+					convert "$script_location/$icon_filename" -trim -background none -resize 256X256 -define 'icon:auto-resize=16,24,32,64,128,256'  "$script_location/${icon_filename%.$ext}.ico"
+					icon_filename="${icon_filename%.$ext}.ico"
+				elif [[ "$ext" == "png" ]] || [[ "$ext" == "xpm" ]]; then
 					echo "${info} Converting $ext icon to ico..."
 					convert "$script_location/$icon_filename" -resize 256X256 "$script_location/${icon_filename%.$ext}.ico"
 					icon_filename="${icon_filename%.$ext}.ico"


### PR DESCRIPTION
## Description
Upon conversion of svg icons i got a white border around the icon. In my case with PyCharm when using the svg icon. The changes remove this white border around the icon.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read Code of Conduct and Contributing documentations.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.