### PR TITLE
wslsys: Increase speed of registry queries

### DIFF
--- a/src/wslsys.sh
+++ b/src/wslsys.sh
@@ -3,10 +3,14 @@ version="28"
 help_short="wslsys (-h|-v|-S|-U|-b|-B|-fB|-R|-K|-P) -s"
 
 ## Windows 10 information
-branch=$(winps_exec "(Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion').'BuildBranch'")
-build=$(winps_exec "(Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion').'CurrentBuild'")
-full_build=$(winps_exec "(Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion').'BuildLabEx'")
-installdate=$(winps_exec "(Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion').'InstallDate'")
+branch=`$(interop_prefix)c/Windows/System32/reg.exe query "HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion" /v BuildBranch | tail -n 2 | head -n 1`
+branch=${branch##* }
+build=`$(interop_prefix)c/Windows/System32/reg.exe query "HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion" /v CurrentBuild | tail -n 2 | head -n 1`
+build=${build##* }
+full_build=`$(interop_prefix)c/Windows/System32/reg.exe query "HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion" /v BuildLabEx | tail -n 2 | head -n 1`
+full_build=${full_build##* }
+installdate=`$(interop_prefix)c/Windows/System32/reg.exe query "HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion" /v InstallDate | tail -n 2 | head -n 1`
+installdate=${installdate##* }
 
 ## WSL information
 release="$(grep "PRETTY_NAME=" /etc/os-release | sed -e 's/PRETTY_NAME=//g' -e 's/"//g')"


### PR DESCRIPTION
I have used regular `reg query` commands instead of Powershell to get the registry values for wslsys.

## Description
On my system, Powershell takes a good deal of time (0.5 seconds or more) to load. Take that 4 times for wslsys, that means 2 seconds. Take that times 4 (I think even more) in wslfetch, we get to 10 or more seconds. My approach, using `reg query` commands which are faster, considerably helps alleviate this issue.

Fixes #84.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read Code of Conduct and Contributing documentations.
- [ ] My code follows the code style of this project.