### PR TITLE
wslfetch: only run wslsys once

### DIFF
--- a/src/wslfetch.sh
+++ b/src/wslfetch.sh
@@ -16,11 +16,12 @@ for args; do
 done
 
 hostname=$(</etc/hostname)
-branch=$(wslsys -b -s)
-build=$(wslsys -B -s)
-release=$(wslsys -R -s)
-kernel=$(wslsys -K -s)
-uptime=$(wslsys -wU -s)
+wslsys=$(wslsys)
+branch=$(echo "$wslsys" | grep -Po '^Branch: \K.*')
+build=$(echo "$wslsys" | grep -Po '^Build: \K.*')
+release=$(echo "$wslsys" | grep -Po '^Linux Release: \K.*')
+kernel=$(echo "$wslsys" | grep -Po '^Linux Kernel: \K.*')
+uptime=$(echo "$wslsys" | grep -Po '^Uptime: \K.*')
 
 case "$distro" in
 	'ubuntu')


### PR DESCRIPTION
## Description

Running `wslsys` is the slowest part of `wslfetch` on my system. This patch updates the latter to only run the former once.

Before:
```bash
$ time wslfetch > /dev/null

real    0m1.205s
user    0m0.141s
sys     0m1.078s
```

After:
```bash
$ time ./wslfetch > /dev/null

real    0m0.349s
user    0m0.016s
sys     0m0.250s
```

On the negative side, this requires that the labels printed by `wslsys` won't be changed in the future.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have read Code of Conduct and Contributing documentations.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.