### PR TITLE
Fixing invalid if then else fi statements

### DIFF
--- a/src/wslu-header
+++ b/src/wslu-header
@@ -121,7 +121,6 @@ function baseexec_gen {
 			# fallback if it is imported repository or other type
 			echo "C:\\Windows\\System32\\wsl.exe" > ~/.config/wslu/baseexec
 		fi
-	fi
 	else
 		# older version fallback.
 		echo "C:\\Windows\\System32\\wsl.exe" > ~/.config/wslu/baseexec


### PR DESCRIPTION
Removed fi before else

The generic if then else fi conditional in shell script was broken( wslvar.sh )
The foll: errors are seen in 2.3.5-2 when running wslvar.

/usr/bin/wslvar: line 125: syntax error near unexpected token `else'
/usr/bin/wslvar: line 125: `    else'

## Description
Fixed the if then else fi conditional

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read Code of Conduct and Contributing documentations.
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.