### PR TITLE
Update MakeFile to use system installed bats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ clean:
 	rm -rf $(OUTMANPATH)
 
 test: 
-	extras/bats/bin/bats -r tests
+	bats -r tests
 
 coverage: 
 	kcov --include-path="./src,./out" ./tests/coverage ./extras/bats/bin/bats -r tests

--- a/configure.sh
+++ b/configure.sh
@@ -33,30 +33,30 @@ distro="$(head -n1 /etc/os-release | sed -e 's/NAME=\"//g')"
 case $distro in
 	*Pengwin*)
 		sudo dpkg --force-depends --remove wslu
-		sudo apt install -y git gzip make
+		sudo apt install -y git gzip make bats
 		;;
 	*WLinux*|Ubuntu*|*Debian*|*Kali*)
 		sudo apt purge -y wslu
-		sudo apt install -y git bc gzip make imagemagick
+		sudo apt install -y git bc gzip make imagemagick bats
 		;;
 	openSUSE*|SLES*)
 		sudo zypper -n rm wslu
-		sudo zypper -n install git bc gzip make imagemagick
+		sudo zypper -n install git bc gzip make imagemagick bats
 		;;
 	Alpine*)
-		sudo apk add git bc gzip make bash-completion imagemagick
+		sudo apk add git bc gzip make bash-completion imagemagick bats
 		;;
 	Arch*)
-		sudo pacman -Syyu git bc gzip make bash-completion imagemagick
+		sudo pacman -Syyu git bc gzip make bash-completion imagemagick bats
 		;;
 	*Oracle*|Scientific*)
-		sudo yum install -y git bc gzip make bash-completion imagemagick
+		sudo yum install -y git bc gzip make bash-completion imagemagick bats
 		;;
 	*Fedora*)
-		sudo dnf install -y git bc gzip make bash-completion ImageMagick
+		sudo dnf install -y git bc gzip make bash-completion ImageMagick bats
 		;;
 	*Gentoo*)
-		sudo emerge -a n sys-devel/bc media-gfx/imagemagick app-shells/bash-completion sys-devel/make dev-vcs/git app-arch/gzip
+		sudo emerge -a n sys-devel/bc media-gfx/imagemagick app-shells/bash-completion sys-devel/make dev-vcs/git app-arch/gzip bats
 		;;
 	*Generic*) [ "fedora" == "$(grep -e "LIKE=" /etc/os-release | sed -e 's/ID_LIKE=//g')" ] && sudo dnf install -y git || exit 1;;
 	*) exit 1;;

--- a/configure.sh
+++ b/configure.sh
@@ -56,7 +56,7 @@ case $distro in
 		sudo dnf install -y git bc gzip make bash-completion ImageMagick bats
 		;;
 	*Gentoo*)
-		sudo emerge -a n sys-devel/bc media-gfx/imagemagick app-shells/bash-completion sys-devel/make dev-vcs/git app-arch/gzip bats
+		sudo emerge -a n sys-devel/bc media-gfx/imagemagick app-shells/bash-completion sys-devel/make dev-vcs/git app-arch/gzip dev-util/bats
 		;;
 	*Generic*) [ "fedora" == "$(grep -e "LIKE=" /etc/os-release | sed -e 's/ID_LIKE=//g')" ] && sudo dnf install -y git || exit 1;;
 	*) exit 1;;


### PR DESCRIPTION
A small PR which updates it to a system installed Bats version, if you prefer the Submodule (and in that case, decline this PR) that makes sense. I could rebase this PR with that change in.

## Description
Update MakeFile to use system installed bats instead of the submodule which was previously removed, so contributers are able to run tests :)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] I have read Code of Conduct and Contributing documentations.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.