### PR TITLE
Extend Issue template to include link to ubuntu launchpad

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+# https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: true
+contact_links:
+  - name: "Ubuntu bugs"
+    url: https://bugs.launchpad.net/ubuntu/+source/wslu
+    about: For Ubuntu version, you should not only report bug here but also report bug at Launchpad.


### PR DESCRIPTION
This extends the issue template to remind people to also report Ubuntu bugs on launchpad, to prevent people from going to the issue directly and missing out on creating the issue twice :)

## Description
Like (as an example) on the [Microsoft PowerToys - Create new issue ]( https://github.com/microsoft/PowerToys/issues/new/choose
), this extends the issue template with external links.

This will add the following option to the new issue page.

![image](https://user-images.githubusercontent.com/16852398/94721379-176ca900-0356-11eb-8dec-9fbdfb51223a.png)

I've not disabled the "empty issue" button (which is hidden but still there) so i won't change any additional behaviour.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] I have read Code of Conduct and Contributing documentations.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.