### PR TITLE
Avoid error message when the file doesn't exist

### DIFF
--- a/src/wslu-header
+++ b/src/wslu-header
@@ -183,8 +183,8 @@ function baseexec_gen {
 function var_gen {
 	date +"%s" > ~/.config/wslu/triggered_time
 
-	rm ~/.config/wslu/baseexec
-	rm ~/.config/wslu/oemcp
+	rm -f ~/.config/wslu/baseexec
+	rm -f ~/.config/wslu/oemcp
 
 	# generate oem codepage
 	"$(interop_prefix)$(sysdrive_prefix)"/Windows/System32/reg.exe query "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage" /v OEMCP 2>&1 | sed -n 3p | sed -e 's|\r||g' | grep -o '[[:digit:]]*' > ~/.config/wslu/oemcp


### PR DESCRIPTION
When the distribution was just installed, wslsys displays the following error message:

rm: cannot remove '/home/user/.config/wslu/baseexec': No such file or directory
rm: cannot remove '/home/user/.config/wslu/oemcp': No such file or directory

Adding -f to rm removes this:

       -f, --force
              ignore nonexistent files and arguments, never prompt

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read Code of Conduct and Contributing documentations.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.