### PR TITLE
wslview: possible fix for #198

### DIFF
--- a/src/wslview.sh
+++ b/src/wslview.sh
@@ -42,25 +42,19 @@ if [[ "$lname" != "" ]]; then
 	if [[ "$lname" =~ ^file:\/\/.*$ ]] && [[ ! "$lname" =~ ^file:\/\/(\/)+[A-Za-z]\:.*$ ]]; then
 		[ $wslutmpbuild -ge "$BN_MAY_NINETEEN" ] || error_echo "This protocol is not supported before version 1903." 34
 		properfile_full_path="$(readlink -f "${lname//file:\/\//}")"
-		interop_win_type="$(interop_prefix)$(sysdrive_prefix)"
-		converted_file_path="\\\\wsl\$\\$WSL_DISTRO_NAME${properfile_full_path//\//\\}"
-		[[ "$properfile_full_path" =~ ^${interop_win_type//\/$/}.*$ ]] && converted_file_path="$(wslpath -w "$properfile_full_path")"
+		converted_file_path="$(wslpath -w "$properfile_full_path")"
 		lname="$converted_file_path"
 	# Linux absolute path
 	elif [[ "$lname" =~ ^(/[^/]+)*(/)?$ ]]; then
 		[ $wslutmpbuild -ge "$BN_MAY_NINETEEN" ] || error_echo "This protocol is not supported before version 1903." 34
 		properfile_full_path="$(readlink -f "${lname}")"
-		interop_win_type="$(interop_prefix)$(sysdrive_prefix)"
-		converted_file_path="\\\\wsl\$\\$WSL_DISTRO_NAME${properfile_full_path//\//\\}"
-		[[ "$properfile_full_path" =~ ^${interop_win_type//\/$/}.*$ ]] && converted_file_path="$(wslpath -w "$properfile_full_path")"
+		converted_file_path="$(wslpath -w "$properfile_full_path")"
 		lname="$converted_file_path"
 	# Linux relative path
 	elif [[ -d "$(readlink -f "$lname")" ]] || [[ -f "$(readlink -f "$lname")" ]]; then
 		[ $wslutmpbuild -ge "$BN_MAY_NINETEEN" ] || error_echo "This protocol is not supported before version 1903." 34
 		properfile_full_path="$(readlink -f "${lname}")"
-		interop_win_type="$(interop_prefix)$(sysdrive_prefix)"
-		converted_file_path="\\\\wsl\$\\$WSL_DISTRO_NAME${properfile_full_path//\//\\}"
-		[[ "$properfile_full_path" =~ ^${interop_win_type//\/$/}.*$ ]] && converted_file_path="$(wslpath -w "$properfile_full_path")"
+		converted_file_path="$(wslpath -w "$properfile_full_path")"
 		lname="$converted_file_path"
 	fi
 	winps_exec Start "\"$lname\""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use `wslpath -w` to convert the path to Windows style directly. The original code only use `wslpath -w` for conversion if the path starting with `/mnt/<system drive>`, which causes the path starting with `/mnt/<non-system drive>` to fail to be opend

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read Code of Conduct and Contributing documentations.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.