### PR TITLE
wslvar: Allow variable names with parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can install `wslu` with the following command:
 
 ```
 sudo apt install gnupg2 apt-transport-https
-wget -O - https://pkg.wslutiliti.es/public.key | sudo apt-key add -
+wget -O - https://pkg.wslutiliti.es/public.key | sudo tee -a /etc/apt/trusted.gpg.d/wslu.asc
 echo "deb https://pkg.wslutiliti.es/debian buster main" | sudo tee -a /etc/apt/sources.list
 sudo apt update
 sudo apt install wslu
@@ -109,7 +109,7 @@ You can install `wslu` with the following command:
 
 ```
 sudo apt install gnupg2 apt-transport-https
-wget -O - https://pkg.wslutiliti.es/public.key | sudo apt-key add -
+wget -O - https://pkg.wslutiliti.es/public.key | sudo tee -a /etc/apt/trusted.gpg.d/wslu.asc
 echo "deb https://pkg.wslutiliti.es/kali kali-rolling main" | sudo tee -a /etc/apt/sources.list
 sudo apt update
 sudo apt install wslu

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ You can install `wslu` with the following command:
 
 ```
 sudo apt install gnupg2 apt-transport-https
-wget -O - https://access.patrickwu.space/wslu/public.asc | sudo apt-key add -
-echo "deb https://access.patrickwu.space/wslu/debian buster main" | sudo tee -a /etc/apt/sources.list
+wget -O - https://pkg.wslutiliti.es/public.key | sudo apt-key add -
+echo "deb https://pkg.wslutiliti.es/debian buster main" | sudo tee -a /etc/apt/sources.list
 sudo apt update
 sudo apt install wslu
 ```
@@ -109,8 +109,8 @@ You can install `wslu` with the following command:
 
 ```
 sudo apt install gnupg2 apt-transport-https
-wget -O - https://access.patrickwu.space/wslu/public.asc | sudo apt-key add -
-echo "deb https://access.patrickwu.space/wslu/kali kali-rolling main" | sudo tee -a /etc/apt/sources.list
+wget -O - https://pkg.wslutiliti.es/public.key | sudo apt-key add -
+echo "deb https://pkg.wslutiliti.es/kali kali-rolling main" | sudo tee -a /etc/apt/sources.list
 sudo apt update
 sudo apt install wslu
 ```

--- a/src/wslvar.sh
+++ b/src/wslvar.sh
@@ -14,7 +14,7 @@ function view_shell {
 }
 
 function call_sys {
-	winps_exec "Write-Output \$Env:$*" | cat
+	winps_exec "Write-Output \${Env:$*}" | cat
 }
 
 function view_sys {


### PR DESCRIPTION
In Windows on 64bit systems there is an environment variable named `ProgramFiles(x86)`.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow the use of `wslvar` to access `ProgramFiles(x86)` from Windows in WSL by wrapping the `$env:*` variable with curly braces `{}` so that parentheses are acceptible. This causes `wslvar` to access the PowerShell environment variables as (for example) `${env:ProgramFiles(x86)}` preventing a failure.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read Code of Conduct and Contributing documentations.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.