### PR TITLE
Ensure baseexec works if there are more than one exe in the folder

### DIFF
--- a/src/wslu-header
+++ b/src/wslu-header
@@ -171,7 +171,7 @@ function baseexec_gen {
 			# if it is a store distro
 			wslu_distro_packagename=${wslu_distro_packagename##* }
 			wslu_base_exec_folder_path="$(wslpath "$(winps_exec "[Environment]::GetFolderPath('LocalApplicationData')" | tr -d "\r")\\Microsoft\\WindowsApps\\$wslu_distro_packagename")"
-			wslpath -w "$(find "$wslu_base_exec_folder_path" -name "*.exe")" > ~/.config/wslu/baseexec
+			wslpath -w "$(find "$wslu_base_exec_folder_path" -name "*.exe" -print -quit)" > ~/.config/wslu/baseexec
 		else
 			# if it is imported distro
 			echo "$(wslpath -w "$(interop_prefix)$(sysdrive_prefix)")Windows\\System32\\wsl.exe" > ~/.config/wslu/baseexec


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Now Pengwin has two exe in the folder and the command fails with:

```
wslpath: /mnt/c/Users/user/AppData/Local/Microsoft/WindowsApps/WhitewaterFoundryLtd.Co.16571368D6CFF_kd1vv0z0vy70w/pengwin.exe
/mnt/c/Users/user/AppData/Local/Microsoft/WindowsApps/WhitewaterFoundryLtd.Co.16571368D6CFF_kd1vv0z0vy70w/PengwinW.exe: No such file or directory
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read Code of Conduct and Contributing documentations.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.