### PR TITLE
wslview: fix a bug that it can't open urls

### DIFF
--- a/src/wslview.sh
+++ b/src/wslview.sh
@@ -57,7 +57,7 @@ if [[ "$lname" != "" ]]; then
 		properfile_full_path="$(readlink -f "${lname}")"
 	fi
 	debug_echo "properfile_full_path: $properfile_full_path"
-	cmd="\"$(wslpath -w "${properfile_full_path:-lname}" 2>/dev/null || echo "$lname")\""
+	cmd="\"$(wslpath -w "${properfile_full_path:-}" 2>/dev/null || echo "$lname")\""
 	if [[ "$WSLVIEW_DEFAULT_ENGINE" == "powershell" ]]; then
 		winps_exec Start "${cmd}"
 	elif [[ "$WSLVIEW_DEFAULT_ENGINE" == "cmd" ]]; then


### PR DESCRIPTION
## Description
The command to execute becomes the string `lname` if the argument to `wslview` is not an file path (e.g. an url), due to a typo-ish bug.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

> Breaking change (fix or feature that would cause existing functionality to not work as expected) are no longer accepted

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read Code of Conduct and Contributing documentations.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.