### PR TITLE
Correctly show the wslu version with wslsys -v instead of wslu v

### DIFF
--- a/src/wslu-header
+++ b/src/wslu-header
@@ -171,7 +171,7 @@ For overall help, you can use the command \`man wslu\` or visite the following s
 }
 
 function version {
-	echo "wslu v$wsl_version"
+	echo "wslu v$wslu_version"
 }
 
 function double_dash_p {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When you issue a `wslsys -v` it shows `wslu v` instead of the actual version. This is a variable typo and was solved by calling the right one.

Please add the `hacktoberfest-accepted`label

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

> Breaking change (fix or feature that would cause existing functionality to not work as expected) are no longer accepted

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read Code of Conduct and Contributing documentations.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.