### PR TITLE
Makefile: fix install path error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ res_install:
 	install -Dm 644 src/etc/conf $(DESTDIR)$(PREFIX)/share/wslu
 
 conf_install:
-	install -Dm 644 src/etc/user/conf -t $(DESTDIR)/etc/wslu
+	install -Dm 644 src/etc/user/conf -t $(DESTDIR)$(PREFIX)/etc/wslu
 
 clean:
 	rm -rf $(OUTPATH)


### PR DESCRIPTION
Add $(PREFIX) for conf_install path

<!--- Provide a general summary of your changes in the Title above -->

* Command
```
$ make PREFIX=/local/directory/ install 
```
* Expected message
```
install -Dm 644 src/etc/user/conf -t /local/directory/etc/wslu
```
* Error
```
install: cannot create directory '/etc/wslu': Permission denied
```
* Fix conf_install path in Makefile: add $(PREFIX)

-------------------------------------------------------------------
## Description
<!--- Describe your changes in detail -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

> Breaking change (fix or feature that would cause existing functionality to not work as expected) are no longer accepted

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read Code of Conduct and Contributing documentations.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.