### PR TITLE
bugfix: sysdrive_prefix returning wrong label when Windows installed at label other than C:

### DIFF
--- a/src/wslu-header
+++ b/src/wslu-header
@@ -206,14 +206,13 @@ function interop_prefix {
 }
 
 function sysdrive_prefix {
-	win_location="$(interop_prefix)"
 	hard_reset=0
-	for pt in "$win_location"/*; do
+	for pt in "$(interop_prefix)"/*; do
 		[[ -e "$pt" ]] || break
 		if [ "$(echo "$pt" | wc -l)" -eq 1 ]; then
-			if [ -d "$win_location$pt/Windows/System32" ]; then
+			if [ -d "$pt/Windows/System32" ]; then
 				hard_reset=1
-				win_location="$pt"
+				win_location="$(echo "$pt" | sed -e 's,^'"$(interop_prefix)"'/,,')"
 				break
 			fi
 		fi 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
My PC have Windows installed at `w:/` which would be mounted in wsl at `/mnt/w`. I found that wslu got wrong path `/mnt/c`.  A bugfix is needed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

> Breaking change (fix or feature that would cause existing functionality to not work as expected) are no longer accepted

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read Code of Conduct and Contributing documentations.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

notice: I've ran all bats tests, but some tests assumed Windows is locating at `/mnt/c`, so they got fail in my environment, this is not a real problem IMO.