### PR TITLE
Add support for Rocky to installer

### DIFF
--- a/extras/scripts/wslu-install
+++ b/extras/scripts/wslu-install
@@ -24,7 +24,7 @@ case $distro in
 	Alpine*) sudo apk add git;;
 	Arch*) sudo pacman -Syyu git --noconfirm;;
 	Scientific*) sudo yum install -y git;;
-	*Fedora*) sudo dnf install -y git;;
+	*Fedora*|*Rocky*) sudo dnf install -y git;;
 	*Gentoo*) sudo emerge -a n dev-vcs/git;;
 	*Generic*) [ "fedora" == "$(cat /etc/os-release | grep -e "LIKE=" | sed -e 's/ID_LIKE=//g')" ] && sudo dnf install -y git || exit 1;;
 	*) exit 1;;


### PR DESCRIPTION
I have been following Rocky Linux's [Guide](https://docs.rockylinux.org/guides/interoperability/import_rocky_to_wsl/) for setting up Rocky in WSL and noticed that the wslu installer script would not detect Rocky properly.

Currently when you try to use the installer script on Rocky in WSL it just silently fails.

This makes it possible to use the installer on Rocky in WSL.

## Description
Adding Rocky to the distro in the case statement of the installer script.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

> Breaking change (fix or feature that would cause existing functionality to not work as expected) are no longer accepted

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read Code of Conduct and Contributing documentations.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.