### PR TITLE
wslact: improve memory-reclaim command

### DIFF
--- a/docs/wslact.1
+++ b/docs/wslact.1
@@ -14,7 +14,7 @@ Currently, we have two features available:
 .nf
 \fBts, time-sync\fR \- Time Sync
 \fBam, auto-mount\fR \- Auto Mounting
-\fBmr, mem-reclaim\fR \- Memory Reclaimation
+\fBmr, memory-reclaim\fR \- Memory Reclamation
 .fi
 .in
 .SH COMMANDS
@@ -52,11 +52,11 @@ pass a list of options you want to pass to \fImount\fR command.
 print a simple help.
 .in
 .fi
-.SS "Memory Reclaimation"
-Memory Reclaimation (\fImem-reclaim\fR) feature allows you to reclaim memory by dropping memory cache. Requires sudo.
+.SS "Memory Reclamation"
+Memory Reclamation (\fImemory-reclaim\fR) feature allows you to reclaim memory by dropping memory cache. Requires sudo.
 .TP
 SYNOPSIS
-.B wslact auto-mount
+.B wslact memory-reclaim
 .RB [ \-h ]
 .TP
 OPTIONS

--- a/src/wslact.sh
+++ b/src/wslact.sh
@@ -101,7 +101,7 @@ while [ "$1" != "" ]; do
 	case "$1" in
 		ts|time-sync|tr|time-reset) time_reset "$@"; exit;;
 		am|auto-mount|sm|smart-mount) auto_mount "$@"; exit;;
-		mr|mem-reclaim) memory_reclaim "$@"; exit;;
+		mr|memory-reclaim|mem-reclaim) memory_reclaim "$@"; exit;;
 		-h|--help) help "$0" "$help_short"; exit;;
 		-v|--version) version; exit;;
 		*) error_echo "Invalid Input. Aborted." 22;;

--- a/src/wslact.sh
+++ b/src/wslact.sh
@@ -93,6 +93,7 @@ function memory_reclaim {
 		error_echo "\`wslact memory-reclaim\` requires you to run as root. Aborted." 1
 	fi
 
+	sync
 	echo 1 > /proc/sys/vm/drop_caches
 	echo "${info} Memory Reclaimed."
 }

--- a/tests/wslact.bats
+++ b/tests/wslact.bats
@@ -60,3 +60,27 @@
   [ "${lines[0]}" = "wslact - Part of wslu, a collection of utilities for Linux Subsystem for Windows (WSL)" ]
   [ "${lines[1]}" = "Usage: wslact auto-mount [-mh]" ]
 }
+
+@test "wslact - Memory Reclamation - Help" {
+  run out/wslact memory-reclaim --help
+  [ "${lines[0]}" = "wslact - Part of wslu, a collection of utilities for Linux Subsystem for Windows (WSL)" ]
+  [ "${lines[1]}" = "Usage: wslact memory-reclaim [-h]" ]
+}
+
+@test "wslact - Memory Reclamation - Help - Alt." {
+  run out/wslact memory-reclaim -h
+  [ "${lines[0]}" = "wslact - Part of wslu, a collection of utilities for Linux Subsystem for Windows (WSL)" ]
+  [ "${lines[1]}" = "Usage: wslact memory-reclaim [-h]" ]
+}
+
+@test "wslact - Memory Reclamation - short form - Help" {
+  run out/wslact mr --help
+  [ "${lines[0]}" = "wslact - Part of wslu, a collection of utilities for Linux Subsystem for Windows (WSL)" ]
+  [ "${lines[1]}" = "Usage: wslact memory-reclaim [-h]" ]
+}
+
+@test "wslact - Memory Reclamation - short form - Help - Alt." {
+  run out/wslact mr -h
+  [ "${lines[0]}" = "wslact - Part of wslu, a collection of utilities for Linux Subsystem for Windows (WSL)" ]
+  [ "${lines[1]}" = "Usage: wslact memory-reclaim [-h]" ]
+}


### PR DESCRIPTION
Currently, there is incoherence in command naming between docs, and its help command.

In the docs of the `wslact` in the `SYNOPSIS` was `wslact auto-mount`.
In the help command, there is an alias `memory-reclaim`, which doesn't exist at the moment.

Also, [it is possible to increase the amount of dropping cache](https://www.kernel.org/doc/Documentation/sysctl/vm.txt) by calling `sync` before.

## Description
- in the docs, I changed `mem-reclaim` to `memory-reclaim`  to keep coherence with the help command
- added `memory-reclaim`, keeping `mem-reclaim` as the alias
- wrote tests for `memory-reclaim` and `mr`, same as tests for other commands in the `wslact`
- fixed typo `reclaimation` -> `reclamation`
- added `sync` before dropping the cache

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

> Breaking change (fix or feature that would cause existing functionality to not work as expected) are no longer accepted

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read Code of Conduct and Contributing documentations.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.