### PR TITLE
wslview: fix opening links with brackets

### DIFF
--- a/src/wslview.sh
+++ b/src/wslview.sh
@@ -25,7 +25,7 @@ function add_reg_alt {
 }
 
 function url_validator {
- content=$(curl --head --silent "$*" | head -n 1)
+ content=$(curl --head --silent -g "$*" | head -n 1)
  if [ -n "$content" ]; then
  	return 0
  else

--- a/tests/wslview.bats
+++ b/tests/wslview.bats
@@ -95,3 +95,8 @@ setup() {
   run out/wslview "https://wslutiliti.es/"
   [ "$status" -eq 0 ]
 }
+
+@test "wslview - Internet - with brackets" {
+  run out/wslview "https://www.duckduckgo.com/?q=[wslu]"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Description

curl treats brackets as special glob characters, but powershell does not have that same behavior so it should be better to turn off curl globbing.

Fixes https://github.com/wslutilities/wslu/issues/284

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

> Breaking change (fix or feature that would cause existing functionality to not work as expected) are no longer accepted

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read Code of Conduct and Contributing documentations.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.