### PR TITLE
fix: [#268] do not validate URL when skip flag is used

### DIFF
--- a/src/wslview.sh
+++ b/src/wslview.sh
@@ -98,11 +98,12 @@ if [[ "$lname" != "" ]]; then
 		properfile_full_path="$(readlink -f "${lname}")"
 	fi
 	debug_echo "properfile_full_path: $properfile_full_path"
-	debug_echo "validating whether if it is a link"
-	is_valid_url=$(url_validator "$lname")
 	if [ "$skip_validation_check" -eq 0 ]; then
 		debug_echo "Skipping validation check"
 		is_valid_url=0
+  	else
+   		debug_echo "Validating whether if it is a link"
+   		is_valid_url=$(url_validator "$lname")
 	fi
 	if [[ "$is_valid_url" -eq 0 ]] && [ -z "$properfile_full_path" ]; then
 		debug_echo "It is a link"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I stumbled upon #268 and saw you added the `-s, --skip-validation-check` flag. I checked the fix, but if I interpret the code correctly, it still does validate the URL, but now it just ignores the result. This does not fix the issue with one-time URL's described in https://github.com/wslutilities/wslu/issues/268#issuecomment-1476208820. The name of the flag also suggests it completely skips the check instead of ignoring the result, so that's what I changed it into.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

> Breaking change (fix or feature that would cause existing functionality to not work as expected) are no longer accepted

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read Code of Conduct and Contributing documentations.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.