### PR TITLE
feat: register wslview as a XDG MIME applications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ uninstall:
 	done
 	rm -rf $(DESTDIR)$(PREFIX)/share/man/man7/wslu.7.gz
 	rm -rf $(DESTDIR)$(PREFIX)/share/wslu
+	rm -f $(DESTDIR)$(PREFIX)/share/applications/wslview.desktop
 
 doc:
 	[ -d $(OUTMANPATH) ] || mkdir $(OUTMANPATH)
@@ -61,7 +62,7 @@ res_install:
 	install -Dm 644 src/etc/*.ps1 -t $(DESTDIR)$(PREFIX)/share/wslu
 	install -Dm 644 src/etc/*.ico -t $(DESTDIR)$(PREFIX)/share/wslu
 	install -Dm 755 src/etc/*.sh -t $(DESTDIR)$(PREFIX)/share/wslu
-	install -Dm 644 src/etc/*.desktop $(DESTDIR)$(PREFIX)/share/wslu
+	install -Dm 644 src/etc/wslview.desktop -t $(DESTDIR)$(PREFIX)/share/applications
 	install -Dm 644 src/etc/conf $(DESTDIR)$(PREFIX)/share/wslu
 
 conf_install:


### PR DESCRIPTION
This change allows desktop environment to find and use wslview to open registered MIME types.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`wslview.desktop` was installed in `/usr/share/wslu/` before, which has no effect. I move it to the standard `/usr/share/applications/`, so that it can be used by desktop environment tools, e.g., `xdg-open`. And this solves the problem that `wslview` cannot registered itself as the default browser on Arch Linux.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

> Breaking change (fix or feature that would cause existing functionality to not work as expected) are no longer accepted

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read Code of Conduct and Contributing documentations.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.